### PR TITLE
fix: add react-native-view-shot and relax node/npm engine requirements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
 				"react-native-safe-area-context": "~5.6.0",
 				"react-native-screens": "~4.16.0",
 				"react-native-url-polyfill": "^3.0.0",
+				"react-native-view-shot": "^4.0.3",
 				"react-native-web": "^0.21.0"
 			},
 			"devDependencies": {
@@ -47,8 +48,8 @@
 				"typescript": "~5.9.2"
 			},
 			"engines": {
-				"node": "20.20.0",
-				"npm": "10.8.2"
+				"node": ">=20.20.0",
+				"npm": ">=10.8.2"
 			}
 		},
 		"node_modules/@0no-co/graphql.web": {
@@ -4809,6 +4810,15 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"license": "MIT"
 		},
+		"node_modules/base64-arraybuffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+			"integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6.0"
+			}
+		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -5538,6 +5548,15 @@
 			"license": "MIT",
 			"dependencies": {
 				"hyphenate-style-name": "^1.0.3"
+			}
+		},
+		"node_modules/css-line-break": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+			"integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+			"license": "MIT",
+			"dependencies": {
+				"utrie": "^1.0.2"
 			}
 		},
 		"node_modules/csstype": {
@@ -7455,6 +7474,19 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
 			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
 			"license": "ISC"
+		},
+		"node_modules/html2canvas": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+			"integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+			"license": "MIT",
+			"dependencies": {
+				"css-line-break": "^2.1.0",
+				"text-segmentation": "^1.0.3"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
 		},
 		"node_modules/http-cache-semantics": {
 			"version": "4.2.0",
@@ -10712,6 +10744,19 @@
 				"react-native": "*"
 			}
 		},
+		"node_modules/react-native-view-shot": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/react-native-view-shot/-/react-native-view-shot-4.0.3.tgz",
+			"integrity": "sha512-USNjYmED7C0me02c1DxKA0074Hw+y/nxo+xJKlffMvfUWWzL5ELh/TJA/pTnVqFurIrzthZDPtDM7aBFJuhrHQ==",
+			"license": "MIT",
+			"dependencies": {
+				"html2canvas": "^1.4.1"
+			},
+			"peerDependencies": {
+				"react": "*",
+				"react-native": "*"
+			}
+		},
 		"node_modules/react-native-web": {
 			"version": "0.21.2",
 			"resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
@@ -11946,6 +11991,15 @@
 				"node": "*"
 			}
 		},
+		"node_modules/text-segmentation": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+			"integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+			"license": "MIT",
+			"dependencies": {
+				"utrie": "^1.0.2"
+			}
+		},
 		"node_modules/thenify": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -12328,6 +12382,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/utrie": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+			"integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+			"license": "MIT",
+			"dependencies": {
+				"base64-arraybuffer": "^1.0.2"
 			}
 		},
 		"node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 		"react-native-safe-area-context": "~5.6.0",
 		"react-native-screens": "~4.16.0",
 		"react-native-url-polyfill": "^3.0.0",
+		"react-native-view-shot": "^4.0.3",
 		"react-native-web": "^0.21.0"
 	},
 	"devDependencies": {
@@ -62,8 +63,8 @@
 		"react-test-renderer": "19.1.0"
 	},
 	"engines": {
-		"node": "20.20.0",
-		"npm": "10.8.2"
+		"node": ">=20.20.0",
+		"npm": ">=10.8.2"
 	},
 	"private": true
 }


### PR DESCRIPTION
## 変更内容

- **react-native-view-shot** を追加: `map.tsx` で使用されているが未インストールだったため、バンドルエラーの原因となっていた
- **Node/npm の engine 制限を緩和**: `>=20.20.0` / `>=10.8.2` に変更し、Node 22 など新しいバージョンでも動作するようにした

Made with [Cursor](https://cursor.com)